### PR TITLE
feat: Make Apple Pay iframe native to page instead of modal

### DIFF
--- a/app/components/ApplePayFeature.tsx
+++ b/app/components/ApplePayFeature.tsx
@@ -21,8 +21,6 @@ interface TransactionDetails {
 
 export default function ApplePayFeature() {
   const { address, isConnected } = useAccount();
-  const [showModal, setShowModal] = useState(false);
-  const [showPaymentModal, setShowPaymentModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [email, setEmail] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
@@ -32,7 +30,6 @@ export default function ApplePayFeature() {
   const [destinationAddress, setDestinationAddress] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [paymentLinkUrl, setPaymentLinkUrl] = useState<string | null>(null);
   const [iframeUrl, setIframeUrl] = useState<string | null>(null);
   const [eventLogs, setEventLogs] = useState<string[]>([]);
   const [transactionDetails, setTransactionDetails] = useState<TransactionDetails | null>(null);
@@ -206,10 +203,7 @@ export default function ApplePayFeature() {
       console.log('Environment:', isLocalhost ? 'localhost' : 'production');
       console.log('Payment URL:', iframeUrl);
 
-      setPaymentLinkUrl(originalUrl); // For popup
-      setIframeUrl(iframeUrl); // For iframe
-      setShowModal(false);
-      setShowPaymentModal(true); // Open payment modal
+      setIframeUrl(iframeUrl); // Set iframe URL to show natively
       setEventLogs([
         `[${new Date().toLocaleTimeString()}] Order created successfully`,
         `[${new Date().toLocaleTimeString()}] Loading Apple Pay button...`
@@ -266,435 +260,277 @@ export default function ApplePayFeature() {
               </div>
             ) : (
               <div className="space-y-6">
-                {/* Show error if any */}
-                {error && (
-                  <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm">
-                    {error}
+                {/* Show Success Message if payment completed */}
+                {showSuccessModal && transactionDetails ? (
+                  <div className="text-center">
+                    {/* Success Icon */}
+                    <div className="flex justify-center mb-6">
+                      <div className="w-20 h-20 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center">
+                        <svg className="w-12 h-12 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
+                      </div>
+                    </div>
+
+                    {/* Sandbox Badge */}
+                    <div className="inline-flex items-center px-3 py-1 rounded-full bg-yellow-100 dark:bg-yellow-900/30 border border-yellow-300 dark:border-yellow-700 mb-4">
+                      <span className="text-yellow-700 dark:text-yellow-300 text-sm font-medium">
+                        🧪 Sandbox Transaction - No Real Funds
+                      </span>
+                    </div>
+
+                    <p className="text-center text-gray-600 dark:text-gray-400 mb-6 text-lg">
+                      🎉 Test transaction completed successfully!
+                    </p>
+
+                    {/* Transaction Details */}
+                    <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 space-y-3 mb-6 text-left">
+                      <div className="flex justify-between">
+                        <span className="text-gray-600 dark:text-gray-400">Amount</span>
+                        <span className="font-semibold">${transactionDetails.amount} USD</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-gray-600 dark:text-gray-400">Asset</span>
+                        <span className="font-semibold">{transactionDetails.asset}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-gray-600 dark:text-gray-400">Network</span>
+                        <span className="font-semibold capitalize">{transactionDetails.network}</span>
+                      </div>
+                      <div className="flex justify-between items-start">
+                        <span className="text-gray-600 dark:text-gray-400">To</span>
+                        <span className="font-mono text-xs font-semibold break-all text-right max-w-[300px]">
+                          {transactionDetails.destinationAddress}
+                        </span>
+                      </div>
+                      {transactionDetails.orderId && (
+                        <div className="flex justify-between items-start">
+                          <span className="text-gray-600 dark:text-gray-400">Order ID</span>
+                          <span className="font-mono text-xs font-semibold break-all text-right max-w-[300px]">
+                            {transactionDetails.orderId}
+                          </span>
+                        </div>
+                      )}
+                      <div className="flex justify-between items-start">
+                        <span className="text-gray-600 dark:text-gray-400">Status</span>
+                        <span className="font-semibold text-green-600 dark:text-green-400">
+                          Test Completed ✓
+                        </span>
+                      </div>
+                      {transactionDetails.txHash && transactionDetails.txHash !== '0x' ? (
+                        <div className="flex justify-between items-start">
+                          <span className="text-gray-600 dark:text-gray-400">Tx Hash</span>
+                          <a
+                            href={`https://basescan.org/tx/${transactionDetails.txHash}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-mono text-xs font-semibold text-blue-600 dark:text-blue-400 hover:underline break-all text-right max-w-[300px]"
+                          >
+                            View on BaseScan →
+                          </a>
+                        </div>
+                      ) : (
+                        <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
+                          <p className="text-xs text-gray-500 dark:text-gray-400 italic text-center">
+                            In sandbox mode, no real blockchain transaction occurs.
+                            <br />
+                            In production, you'll receive a transaction hash here.
+                          </p>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Done Button */}
+                    <button
+                      onClick={() => {
+                        setShowSuccessModal(false);
+                        setTransactionDetails(null);
+                        setIframeUrl(null);
+                        // Reset form
+                        setEmail("");
+                        setPhoneNumber("");
+                        setAmount("20");
+                      }}
+                      className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 px-6 rounded-lg transition-all"
+                    >
+                      Start New Transaction
+                    </button>
                   </div>
+                ) : iframeUrl ? (
+                  /* Show Apple Pay iframe natively */
+                  <div className="space-y-4">
+                    {/* Show error if any */}
+                    {error && (
+                      <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm">
+                        {error}
+                      </div>
+                    )}
+
+                    {/* Apple Pay iframe embedded natively */}
+                    <div className="bg-white dark:bg-gray-800 rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700">
+                      <iframe
+                        src={iframeUrl}
+                        className="w-full h-[500px] border-0"
+                        title="Apple Pay Purchase"
+                        allow="payment"
+                        onLoad={() => {
+                          console.log('Apple Pay iframe loaded');
+                          setEventLogs(prev => [...prev, `[${new Date().toLocaleTimeString()}] Apple Pay ready`]);
+                          setIsLoading(false);
+                        }}
+                        onError={(e) => {
+                          console.error('Iframe error:', e);
+                          setError('Failed to load Apple Pay. Try refreshing.');
+                          setIsLoading(false);
+                        }}
+                      />
+                    </div>
+
+                    {/* Back button */}
+                    <button
+                      onClick={() => {
+                        setIframeUrl(null);
+                        setIsLoading(false);
+                        setError(null);
+                      }}
+                      className="w-full text-center py-3 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 font-medium"
+                    >
+                      ← Back to Form
+                    </button>
+                  </div>
+                ) : (
+                  /* Show form */
+                  <>
+                    {/* Show error if any */}
+                    {error && (
+                      <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm">
+                        {error}
+                      </div>
+                    )}
+
+                    {/* Email */}
+                    <div>
+                      <label className="block text-sm font-medium mb-2">
+                        Email (Verified) *
+                      </label>
+                      <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="user@example.com"
+                        className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      />
+                    </div>
+
+                    {/* Phone Number */}
+                    <div>
+                      <label className="block text-sm font-medium mb-2">
+                        Phone Number (US) *
+                      </label>
+                      <input
+                        type="tel"
+                        value={phoneNumber}
+                        onChange={(e) => setPhoneNumber(e.target.value)}
+                        placeholder="+12345678901"
+                        className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      />
+                      <p className="text-xs text-gray-500 mt-1">Format: +1XXXXXXXXXX</p>
+                    </div>
+
+                    {/* Destination Address */}
+                    <div>
+                      <label className="block text-sm font-medium mb-2">
+                        Destination Address *
+                      </label>
+                      <input
+                        type="text"
+                        value={destinationAddress}
+                        readOnly
+                        placeholder="0x..."
+                        className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 cursor-not-allowed font-mono text-sm"
+                      />
+                      <p className="text-xs text-gray-500 mt-1">Using your connected wallet address</p>
+                    </div>
+
+                    {/* Amount */}
+                    <div>
+                      <label className="block text-sm font-medium mb-2">
+                        Amount (USD)
+                      </label>
+                      <input
+                        type="number"
+                        value={amount}
+                        onChange={(e) => setAmount(e.target.value)}
+                        className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      />
+                    </div>
+
+                    {/* Asset */}
+                    <div>
+                      <label className="block text-sm font-medium mb-2">Asset</label>
+                      <select
+                        value={asset}
+                        onChange={(e) => setAsset(e.target.value)}
+                        className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      >
+                        <option value="USDC">USDC</option>
+                        <option value="ETH">ETH</option>
+                        <option value="BTC">BTC</option>
+                      </select>
+                    </div>
+
+                    {/* Network */}
+                    <div>
+                      <label className="block text-sm font-medium mb-2">Network</label>
+                      <select
+                        value={network}
+                        onChange={(e) => setNetwork(e.target.value)}
+                        className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      >
+                        <option value="base">Base</option>
+                        <option value="ethereum">Ethereum</option>
+                        <option value="polygon">Polygon</option>
+                      </select>
+                    </div>
+
+                    {/* Configuration Display */}
+                    <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+                      <div className="grid grid-cols-2 gap-4 text-sm">
+                        <div>
+                          <span className="text-gray-600 dark:text-gray-400">Amount:</span>
+                          <span className="ml-2 font-medium">${amount} USD</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-600 dark:text-gray-400">Asset:</span>
+                          <span className="ml-2 font-medium">{asset}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-600 dark:text-gray-400">Network:</span>
+                          <span className="ml-2 font-medium capitalize">{network}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-600 dark:text-gray-400">Mode:</span>
+                          <span className="ml-2 font-medium text-green-600">Sandbox</span>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Action Button */}
+                    <button
+                      onClick={handleCreateOrder}
+                      disabled={isLoading || !email || !phoneNumber || !destinationAddress}
+                      className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 disabled:from-gray-400 disabled:to-gray-400 text-white font-semibold py-4 px-6 rounded-xl transition-all transform hover:scale-[1.02] disabled:scale-100 shadow-lg disabled:cursor-not-allowed"
+                    >
+                      {isLoading ? "Creating Order..." : "Add Funds with Apple Pay"}
+                    </button>
+                  </>
                 )}
-
-                {/* Email */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Email (Verified) *
-                  </label>
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="user@example.com"
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  />
-                </div>
-
-                {/* Phone Number */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Phone Number (US) *
-                  </label>
-                  <input
-                    type="tel"
-                    value={phoneNumber}
-                    onChange={(e) => setPhoneNumber(e.target.value)}
-                    placeholder="+12345678901"
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">Format: +1XXXXXXXXXX</p>
-                </div>
-
-                {/* Destination Address */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Destination Address *
-                  </label>
-                  <input
-                    type="text"
-                    value={destinationAddress}
-                    readOnly
-                    placeholder="0x..."
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 cursor-not-allowed font-mono text-sm"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">Using your connected wallet address</p>
-                </div>
-
-                {/* Amount */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Amount (USD)
-                  </label>
-                  <input
-                    type="number"
-                    value={amount}
-                    onChange={(e) => setAmount(e.target.value)}
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  />
-                </div>
-
-                {/* Asset */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">Asset</label>
-                  <select
-                    value={asset}
-                    onChange={(e) => setAsset(e.target.value)}
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  >
-                    <option value="USDC">USDC</option>
-                    <option value="ETH">ETH</option>
-                    <option value="BTC">BTC</option>
-                  </select>
-                </div>
-
-                {/* Network */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">Network</label>
-                  <select
-                    value={network}
-                    onChange={(e) => setNetwork(e.target.value)}
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  >
-                    <option value="base">Base</option>
-                    <option value="ethereum">Ethereum</option>
-                    <option value="polygon">Polygon</option>
-                  </select>
-                </div>
-
-                {/* Configuration Display */}
-                <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
-                  <div className="grid grid-cols-2 gap-4 text-sm">
-                    <div>
-                      <span className="text-gray-600 dark:text-gray-400">Amount:</span>
-                      <span className="ml-2 font-medium">${amount} USD</span>
-                    </div>
-                    <div>
-                      <span className="text-gray-600 dark:text-gray-400">Asset:</span>
-                      <span className="ml-2 font-medium">{asset}</span>
-                    </div>
-                    <div>
-                      <span className="text-gray-600 dark:text-gray-400">Network:</span>
-                      <span className="ml-2 font-medium capitalize">{network}</span>
-                    </div>
-                    <div>
-                      <span className="text-gray-600 dark:text-gray-400">Mode:</span>
-                      <span className="ml-2 font-medium text-green-600">Sandbox</span>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Action Button */}
-                <button
-                  onClick={handleCreateOrder}
-                  disabled={isLoading || !email || !phoneNumber || !destinationAddress}
-                  className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 disabled:from-gray-400 disabled:to-gray-400 text-white font-semibold py-4 px-6 rounded-xl transition-all transform hover:scale-[1.02] disabled:scale-100 shadow-lg disabled:cursor-not-allowed"
-                >
-                  {isLoading ? "Creating Order..." : "Add Funds with Apple Pay"}
-                </button>
               </div>
             )}
           </div>
 
-          {/* Payment Modal - Shows Apple Pay iframe or Success Message */}
-          {showPaymentModal && iframeUrl && (
-            <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-              <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-lg w-full max-h-[90vh] overflow-y-auto">
-                <div className="p-6">
-                  <div className="flex justify-between items-center mb-6">
-                    <h2 className="text-2xl font-bold">{showSuccessModal ? "Payment Successful!" : "Add funds"}</h2>
-                    <button
-                      onClick={() => {
-                        setShowPaymentModal(false);
-                        setShowSuccessModal(false);
-                        setPaymentLinkUrl(null);
-                        setIframeUrl(null);
-                        setIsLoading(false);
-                        setTransactionDetails(null);
-                        // Reset form if success
-                        if (showSuccessModal) {
-                          setEmail("");
-                          setPhoneNumber("");
-                          setAmount("20");
-                        }
-                      }}
-                      className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                    >
-                      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                      </svg>
-                    </button>
-                  </div>
-
-                  {/* Show error if any */}
-                  {error && !showSuccessModal && (
-                    <div className="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm">
-                      {error}
-                    </div>
-                  )}
-
-                  {/* Show Success Message or Apple Pay iframe */}
-                  {showSuccessModal && transactionDetails ? (
-                    <div className="text-center">
-                      {/* Success Icon */}
-                      <div className="flex justify-center mb-6">
-                        <div className="w-20 h-20 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center">
-                          <svg className="w-12 h-12 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                          </svg>
-                        </div>
-                      </div>
-
-                      {/* Sandbox Badge */}
-                      <div className="inline-flex items-center px-3 py-1 rounded-full bg-yellow-100 dark:bg-yellow-900/30 border border-yellow-300 dark:border-yellow-700 mb-4">
-                        <span className="text-yellow-700 dark:text-yellow-300 text-sm font-medium">
-                          🧪 Sandbox Transaction - No Real Funds
-                        </span>
-                      </div>
-
-                      <p className="text-center text-gray-600 dark:text-gray-400 mb-6 text-lg">
-                        🎉 Test transaction completed successfully!
-                      </p>
-
-                      {/* Transaction Details */}
-                      <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 space-y-3 mb-6 text-left">
-                        <div className="flex justify-between">
-                          <span className="text-gray-600 dark:text-gray-400">Amount</span>
-                          <span className="font-semibold">${transactionDetails.amount} USD</span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span className="text-gray-600 dark:text-gray-400">Asset</span>
-                          <span className="font-semibold">{transactionDetails.asset}</span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span className="text-gray-600 dark:text-gray-400">Network</span>
-                          <span className="font-semibold capitalize">{transactionDetails.network}</span>
-                        </div>
-                        <div className="flex justify-between items-start">
-                          <span className="text-gray-600 dark:text-gray-400">To</span>
-                          <span className="font-mono text-xs font-semibold break-all text-right max-w-[300px]">
-                            {transactionDetails.destinationAddress}
-                          </span>
-                        </div>
-                        {transactionDetails.orderId && (
-                          <div className="flex justify-between items-start">
-                            <span className="text-gray-600 dark:text-gray-400">Order ID</span>
-                            <span className="font-mono text-xs font-semibold break-all text-right max-w-[300px]">
-                              {transactionDetails.orderId}
-                            </span>
-                          </div>
-                        )}
-                        <div className="flex justify-between items-start">
-                          <span className="text-gray-600 dark:text-gray-400">Status</span>
-                          <span className="font-semibold text-green-600 dark:text-green-400">
-                            Test Completed ✓
-                          </span>
-                        </div>
-                        {transactionDetails.txHash && transactionDetails.txHash !== '0x' ? (
-                          <div className="flex justify-between items-start">
-                            <span className="text-gray-600 dark:text-gray-400">Tx Hash</span>
-                            <a
-                              href={`https://basescan.org/tx/${transactionDetails.txHash}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="font-mono text-xs font-semibold text-blue-600 dark:text-blue-400 hover:underline break-all text-right max-w-[300px]"
-                            >
-                              View on BaseScan →
-                            </a>
-                          </div>
-                        ) : (
-                          <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
-                            <p className="text-xs text-gray-500 dark:text-gray-400 italic text-center">
-                              In sandbox mode, no real blockchain transaction occurs.
-                              <br />
-                              In production, you'll receive a transaction hash here.
-                            </p>
-                          </div>
-                        )}
-                      </div>
-
-                      {/* Done Button */}
-                      <button
-                        onClick={() => {
-                          setShowPaymentModal(false);
-                          setShowSuccessModal(false);
-                          setTransactionDetails(null);
-                          setPaymentLinkUrl(null);
-                          setIframeUrl(null);
-                          // Reset form
-                          setEmail("");
-                          setPhoneNumber("");
-                          setAmount("20");
-                        }}
-                        className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-semibold py-3 px-6 rounded-lg transition-all"
-                      >
-                        Done
-                      </button>
-                    </div>
-                  ) : (
-                    <>
-                      {/* Apple Pay iframe */}
-                      <div className="bg-white dark:bg-gray-800 rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700 mb-4">
-                        <iframe
-                          src={iframeUrl}
-                          className="w-full h-[500px] border-0"
-                          title="Apple Pay Purchase"
-                          allow="payment"
-                          onLoad={() => {
-                            console.log('Apple Pay iframe loaded');
-                            setEventLogs(prev => [...prev, `[${new Date().toLocaleTimeString()}] Apple Pay ready`]);
-                            setIsLoading(false);
-                          }}
-                          onError={(e) => {
-                            console.error('Iframe error:', e);
-                            setError('Failed to load Apple Pay. Try refreshing.');
-                            setIsLoading(false);
-                          }}
-                        />
-                      </div>
-
-                      {/* Back button */}
-                      <button
-                        onClick={() => {
-                          setShowPaymentModal(false);
-                          setPaymentLinkUrl(null);
-                          setIframeUrl(null);
-                          setIsLoading(false);
-                        }}
-                        className="w-full text-center py-3 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 font-medium mt-4"
-                      >
-                        Back
-                      </button>
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
         </div>
       </div>
-
-      {/* Configuration Modal - Hidden for now, using auto-fill */}
-      {false && showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-md w-full max-h-[90vh] overflow-y-auto">
-            <div className="p-6">
-              <div className="flex justify-between items-center mb-6">
-                <h2 className="text-2xl font-bold">Add Funds</h2>
-                <button
-                  onClick={() => setShowModal(false)}
-                  className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                >
-                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-                Select deposit method
-              </p>
-
-              <div className="space-y-4">
-                {/* Email */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Email (Verified) *
-                  </label>
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="user@example.com"
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  />
-                </div>
-
-                {/* Phone Number */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Phone Number (US) *
-                  </label>
-                  <input
-                    type="tel"
-                    value={phoneNumber}
-                    onChange={(e) => setPhoneNumber(e.target.value)}
-                    placeholder="+12345678901"
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">Format: +1XXXXXXXXXX</p>
-                </div>
-
-                {/* Destination Address */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Destination Address *
-                  </label>
-                  <input
-                    type="text"
-                    value={destinationAddress}
-                    readOnly
-                    placeholder="0x..."
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 cursor-not-allowed font-mono text-sm"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">Using your connected wallet address</p>
-                </div>
-
-                {/* Amount */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Amount (USD)
-                  </label>
-                  <input
-                    type="number"
-                    value={amount}
-                    onChange={(e) => setAmount(e.target.value)}
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  />
-                </div>
-
-                {/* Asset */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">Asset</label>
-                  <select
-                    value={asset}
-                    onChange={(e) => setAsset(e.target.value)}
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  >
-                    <option value="USDC">USDC</option>
-                    <option value="ETH">ETH</option>
-                    <option value="BTC">BTC</option>
-                  </select>
-                </div>
-
-                {/* Network */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">Network</label>
-                  <select
-                    value={network}
-                    onChange={(e) => setNetwork(e.target.value)}
-                    className="w-full px-4 py-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  >
-                    <option value="base">Base</option>
-                    <option value="ethereum">Ethereum</option>
-                    <option value="polygon">Polygon</option>
-                  </select>
-                </div>
-
-                {error && (
-                  <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm">
-                    {error}
-                  </div>
-                )}
-
-                <button
-                  onClick={handleCreateOrder}
-                  disabled={isLoading || !destinationAddress}
-                  className="w-full bg-black dark:bg-white text-white dark:text-black font-semibold py-4 px-6 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-100 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
-                >
-                  {isLoading ? "Creating Order..." : "Buy with Apple Pay"}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
Removes modal/popup overlay in favor of inline iframe display for a cleaner, more focused user experience.

Changes:
- Remove modal popup states (showModal, showPaymentModal)
- Display iframe directly in main card area after order creation